### PR TITLE
feat: support associated languages

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/setFlowVariablesFromRadarrOrSonarr/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/setFlowVariablesFromRadarrOrSonarr/1.0.0/index.js
@@ -49,6 +49,9 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.plugin = exports.details = void 0;
 var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
+module.exports.dependencies = [
+    'iso639-js@1.1.3',
+];
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 // ===== CONSTANTS =====
 var NOT_FOUND_ID = '-1';
@@ -56,20 +59,22 @@ var DEFAULT_SEASON = 1;
 var DEFAULT_EPISODE = 1;
 var DEFAULT_EPISODE_ID = '1';
 var DEFAULT_LANGUAGE_CODE = 'und';
-var LANGUAGE_API_TIMEOUT = 5000;
 var ARR_API_TIMEOUT = 10000;
 var API_HEADERS = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
 };
-// eslint-disable-next-line max-len
-var LANGUAGE_API_BASE_URL = 'https://data.opendatasoft.com/api/explore/v2.1/catalog/datasets/iso-language-codes-639-1-and-639-2@public/records';
 var details = function () { return ({
     name: 'Set Flow Variables From Radarr Or Sonarr',
     description: 'Set Flow Variables From Radarr or Sonarr. The variables set are : '
         + 'ArrId (internal id for Radarr or Sonarr), '
-        + 'ArrOriginalLanguageCode (code of the orignal language (ISO 639-2) as know by Radarr or Sonarr), '
-        + 'ArrProfileLanguageCode (code of the orignal language (ISO 639-2) as know by Radarr or Sonarr), '
+        + 'ArrOriginalLanguageCode (primary original language code (ISO 639-2) as known by Radarr or Sonarr), '
+        + 'ArrOriginalLanguageCodes (comma-separated string of ISO 639-2 language codes, '
+        + 'including the primary and associated language codes), '
+        + 'ArrProfileLanguageCode (primary original language code (ISO 639-2) as known by Radarr or Sonarr), '
+        + 'ArrProfileLanguageCodes (comma-separated string of ISO 639-2 language codes, '
+        + 'including the primary and associated language codes), '
+        + 'including the maco-language code and associated individual language codes), '
         + 'ArrSeasonNumber (the season number of the episode), '
         + 'ArrEpisodeNumber (the episode number).',
     style: {
@@ -363,132 +368,71 @@ var parseContent = function (args, config, fileName) { return __awaiter(void 0, 
         }
     });
 }); };
-var languageCodeCache = new Map();
-/**
- * Fetches ISO 639-2 language code from language name using external API
- * Implements caching to avoid redundant API calls
- * @param args - Plugin input arguments
- * @param languageName - The language name to look up
- * @returns ISO 639-2 (alpha3_b) language code or DEFAULT_LANGUAGE_CODE
- */
-var getLanguageCode = function (args, languageName) { return __awaiter(void 0, void 0, void 0, function () {
-    var normalizedName, cachedValue, url, data, languageCode, error_5, errorMessage;
-    var _a, _b, _c;
-    return __generator(this, function (_d) {
-        switch (_d.label) {
-            case 0:
-                if (!languageName || languageName.trim() === '') {
-                    return [2 /*return*/, ''];
-                }
-                normalizedName = languageName.trim().toLowerCase();
-                cachedValue = languageCodeCache.get(normalizedName);
-                if (cachedValue !== undefined) {
-                    return [2 /*return*/, cachedValue];
-                }
-                _d.label = 1;
-            case 1:
-                _d.trys.push([1, 3, , 4]);
-                url = "".concat(LANGUAGE_API_BASE_URL, "?select=alpha3_b&where=english%20%3D%20%22").concat(encodeURIComponent(languageName), "%22&limit=1");
-                return [4 /*yield*/, args.deps.axios({
-                        method: 'get',
-                        url: url,
-                        timeout: LANGUAGE_API_TIMEOUT,
-                    })];
-            case 2:
-                data = (_d.sent()).data;
-                languageCode = (_c = (_b = (_a = data.results) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.alpha3_b) !== null && _c !== void 0 ? _c : DEFAULT_LANGUAGE_CODE;
-                // Cache the result
-                languageCodeCache.set(normalizedName, languageCode);
-                return [2 /*return*/, languageCode];
-            case 3:
-                error_5 = _d.sent();
-                errorMessage = error_5 instanceof Error ? error_5.message : String(error_5);
-                args.jobLog("Failed to fetch language code for \"".concat(languageName, "\": ").concat(errorMessage));
-                return [2 /*return*/, DEFAULT_LANGUAGE_CODE];
-            case 4: return [2 /*return*/];
-        }
-    });
-}); };
 /**
  * Sets flow variables based on file information from Radarr/Sonarr
- * Uses parallel language code fetching for better performance
  * @param args - Plugin input arguments
  * @param fileInfo - The file information to set variables from
  */
-var setVariables = function (args, fileInfo) { return __awaiter(void 0, void 0, void 0, function () {
-    var _a, originalLanguageCode, profileLanguageCode, _b;
-    var _c;
-    var _d, _e, _f, _g, _h, _j;
-    return __generator(this, function (_k) {
-        switch (_k.label) {
-            case 0:
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user = args.variables.user || {};
-                // Set common variables
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user.ArrId = fileInfo.id;
-                args.jobLog("Setting variable ArrId to ".concat(args.variables.user.ArrId));
-                if (!(fileInfo.type === 'sonarr')) return [3 /*break*/, 2];
-                // eslint-disable-next-line no-param-reassign
-                _a = args.variables.user;
-                return [4 /*yield*/, getLanguageCode(args, (_d = fileInfo.originalLanguageName) !== null && _d !== void 0 ? _d : '')];
-            case 1:
-                // eslint-disable-next-line no-param-reassign
-                _a.ArrOriginalLanguageCode = _k.sent();
-                args.jobLog("Setting variable ArrOriginalLanguageCode to ".concat(args.variables.user.ArrOriginalLanguageCode));
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user.ArrSeasonNumber = String(fileInfo.seasonNumber);
-                args.jobLog("Setting variable ArrSeasonNumber to ".concat(args.variables.user.ArrSeasonNumber));
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user.ArrEpisodeNumber = String(fileInfo.episodeNumber);
-                args.jobLog("Setting variable ArrEpisodeNumber to ".concat(args.variables.user.ArrEpisodeNumber));
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user.ArrEpisodeId = fileInfo.episodeId;
-                args.jobLog("Setting variable ArrEpisodeId to ".concat(args.variables.user.ArrEpisodeId));
-                return [3 /*break*/, 10];
-            case 2:
-                if (!(fileInfo.type === 'radarr')) return [3 /*break*/, 10];
-                originalLanguageCode = '';
-                profileLanguageCode = '';
-                _b = ((_e = fileInfo.profileLanguageName) !== null && _e !== void 0 ? _e : '').toLowerCase();
-                switch (_b) {
-                    case 'original': return [3 /*break*/, 3];
-                    case 'any': return [3 /*break*/, 5];
-                }
-                return [3 /*break*/, 7];
-            case 3:
+var setVariables = function (args, fileInfo) {
+    var _a, _b, _c, _d;
+    // eslint-disable-next-line no-param-reassign
+    args.variables.user = args.variables.user || {};
+    var getISO639part2Languages = require('../../../../FlowHelpers/1.0.0/iso639Helper').getISO639part2Languages;
+    // Set common variables
+    // eslint-disable-next-line no-param-reassign
+    args.variables.user.ArrId = fileInfo.id;
+    args.jobLog("Setting variable ArrId to ".concat(args.variables.user.ArrId));
+    if (fileInfo.type === 'sonarr') {
+        var originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrOriginalLanguageCode = (_a = originalLanguageCodes[0]) !== null && _a !== void 0 ? _a : '';
+        args.jobLog("Setting variable ArrOriginalLanguageCode to ".concat(args.variables.user.ArrOriginalLanguageCode));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrOriginalLanguageCodes = originalLanguageCodes.join(',');
+        args.jobLog("Setting variable ArrOriginalLanguageCodes to ".concat(args.variables.user.ArrOriginalLanguageCodes));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrSeasonNumber = String(fileInfo.seasonNumber);
+        args.jobLog("Setting variable ArrSeasonNumber to ".concat(args.variables.user.ArrSeasonNumber));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrEpisodeNumber = String(fileInfo.episodeNumber);
+        args.jobLog("Setting variable ArrEpisodeNumber to ".concat(args.variables.user.ArrEpisodeNumber));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrEpisodeId = fileInfo.episodeId;
+        args.jobLog("Setting variable ArrEpisodeId to ".concat(args.variables.user.ArrEpisodeId));
+    }
+    else if (fileInfo.type === 'radarr') {
+        var originalLanguageCodes = [];
+        var profileLanguageCodes = [];
+        switch (((_b = fileInfo.profileLanguageName) !== null && _b !== void 0 ? _b : '').toLowerCase()) {
+            case 'original':
                 args.jobLog('Profile language is "Original", using original language');
-                return [4 /*yield*/, getLanguageCode(args, (_f = fileInfo.originalLanguageName) !== null && _f !== void 0 ? _f : '')];
-            case 4:
-                originalLanguageCode = _k.sent();
-                profileLanguageCode = originalLanguageCode;
-                return [3 /*break*/, 9];
-            case 5:
-                args.jobLog('Profile language is "Any", setting to "und" (undetermined)');
-                return [4 /*yield*/, getLanguageCode(args, (_g = fileInfo.originalLanguageName) !== null && _g !== void 0 ? _g : '')];
-            case 6:
-                originalLanguageCode = _k.sent();
-                profileLanguageCode = 'und';
-                return [3 /*break*/, 9];
-            case 7: return [4 /*yield*/, Promise.all([
-                    getLanguageCode(args, (_h = fileInfo.originalLanguageName) !== null && _h !== void 0 ? _h : ''),
-                    getLanguageCode(args, (_j = fileInfo.profileLanguageName) !== null && _j !== void 0 ? _j : ''),
-                ])];
-            case 8:
-                _c = _k.sent(), originalLanguageCode = _c[0], profileLanguageCode = _c[1];
-                return [3 /*break*/, 9];
-            case 9:
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user.ArrOriginalLanguageCode = originalLanguageCode;
-                args.jobLog("Setting variable ArrOriginalLanguageCode to ".concat(originalLanguageCode));
-                // eslint-disable-next-line no-param-reassign
-                args.variables.user.ArrProfileLanguageCode = profileLanguageCode;
-                args.jobLog("Setting variable ArrProfileLanguageCode to ".concat(profileLanguageCode));
-                _k.label = 10;
-            case 10: return [2 /*return*/];
+                originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+                profileLanguageCodes = originalLanguageCodes;
+                break;
+            case 'any':
+                args.jobLog("Profile language is \"Any\", setting to \"".concat(DEFAULT_LANGUAGE_CODE, "\" (undetermined"));
+                originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+                profileLanguageCodes = [DEFAULT_LANGUAGE_CODE];
+                break;
+            default:
+                originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+                profileLanguageCodes = getISO639part2Languages(fileInfo.profileLanguageName || '');
+                break;
         }
-    });
-}); };
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrOriginalLanguageCode = (_c = originalLanguageCodes[0]) !== null && _c !== void 0 ? _c : '';
+        args.jobLog("Setting variable ArrOriginalLanguageCode to ".concat(args.variables.user.ArrOriginalLanguageCode));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrOriginalLanguageCodes = originalLanguageCodes.join(',');
+        args.jobLog("Setting variable ArrOriginalLanguageCodes to ".concat(args.variables.user.ArrOriginalLanguageCodes));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrProfileLanguageCode = (_d = profileLanguageCodes[0]) !== null && _d !== void 0 ? _d : '';
+        args.jobLog("Setting variable ArrProfileLanguageCode to ".concat(args.variables.user.ArrProfileLanguageCode));
+        // eslint-disable-next-line no-param-reassign
+        args.variables.user.ArrProfileLanguageCodes = profileLanguageCodes.join(',');
+        args.jobLog("Setting variable ArrProfileLanguageCodes to ".concat(args.variables.user.ArrProfileLanguageCodes));
+    }
+};
 // ===== MAIN PLUGIN FUNCTION =====
 /**
  * Main plugin function that orchestrates the workflow
@@ -498,7 +442,7 @@ var setVariables = function (args, fileInfo) { return __awaiter(void 0, void 0, 
  * 4. Sets flow variables if content is found
  */
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, config, originalFileName, currentFileName, fileInfo, error_6, errorMessage;
+    var lib, config, originalFileName, currentFileName, fileInfo, error_5, errorMessage;
     var _a, _b, _c, _d;
     return __generator(this, function (_e) {
         switch (_e.label) {
@@ -506,9 +450,12 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 lib = require('../../../../../methods/lib')();
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
                 args.inputs = lib.loadDefaultValues(args.inputs, details);
-                _e.label = 1;
+                return [4 /*yield*/, args.installClassicPluginDeps(module.exports.dependencies)];
             case 1:
-                _e.trys.push([1, 10, , 11]);
+                _e.sent(); // required for iso639Helper.
+                _e.label = 2;
+            case 2:
+                _e.trys.push([2, 9, , 10]);
                 config = {
                     name: args.inputs.arr,
                     host: String(args.inputs.arr_host).trim().replace(/\/$/, ''),
@@ -527,54 +474,53 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 args.jobLog("Processing file: ".concat(originalFileName || currentFileName));
                 args.jobLog("Using ".concat(config.name, " at ").concat(config.host));
                 return [4 /*yield*/, lookupContent(args, config, originalFileName)];
-            case 2:
-                fileInfo = _e.sent();
-                if (!(fileInfo.id === NOT_FOUND_ID && currentFileName !== originalFileName && currentFileName)) return [3 /*break*/, 4];
-                args.jobLog('Lookup failed for original filename, trying current filename');
-                return [4 /*yield*/, lookupContent(args, config, currentFileName)];
             case 3:
                 fileInfo = _e.sent();
-                _e.label = 4;
+                if (!(fileInfo.id === NOT_FOUND_ID && currentFileName !== originalFileName && currentFileName)) return [3 /*break*/, 5];
+                args.jobLog('Lookup failed for original filename, trying current filename');
+                return [4 /*yield*/, lookupContent(args, config, currentFileName)];
             case 4:
-                if (!(fileInfo.id === NOT_FOUND_ID)) return [3 /*break*/, 7];
+                fileInfo = _e.sent();
+                _e.label = 5;
+            case 5:
+                if (!(fileInfo.id === NOT_FOUND_ID)) return [3 /*break*/, 8];
                 args.jobLog('Lookup failed, attempting to parse filename');
                 return [4 /*yield*/, parseContent(args, config, originalFileName)];
-            case 5:
-                fileInfo = _e.sent();
-                if (!(fileInfo.id === NOT_FOUND_ID && currentFileName !== originalFileName && currentFileName)) return [3 /*break*/, 7];
-                args.jobLog('Parse failed for original filename, trying current filename');
-                return [4 /*yield*/, parseContent(args, config, currentFileName)];
             case 6:
                 fileInfo = _e.sent();
-                _e.label = 7;
+                if (!(fileInfo.id === NOT_FOUND_ID && currentFileName !== originalFileName && currentFileName)) return [3 /*break*/, 8];
+                args.jobLog('Parse failed for original filename, trying current filename');
+                return [4 /*yield*/, parseContent(args, config, currentFileName)];
             case 7:
-                if (!(fileInfo.id !== NOT_FOUND_ID && fileInfo.type !== 'unknown')) return [3 /*break*/, 9];
-                args.jobLog("Successfully found content with ID: ".concat(fileInfo.id));
-                return [4 /*yield*/, setVariables(args, fileInfo)];
+                fileInfo = _e.sent();
+                _e.label = 8;
             case 8:
-                _e.sent();
-                return [2 /*return*/, {
-                        outputFileObj: args.inputFileObj,
-                        outputNumber: 1,
-                        variables: args.variables,
-                    }];
-            case 9:
+                // Set variables if content was found
+                if (fileInfo.id !== NOT_FOUND_ID && fileInfo.type !== 'unknown') {
+                    args.jobLog("Successfully found content with ID: ".concat(fileInfo.id));
+                    setVariables(args, fileInfo);
+                    return [2 /*return*/, {
+                            outputFileObj: args.inputFileObj,
+                            outputNumber: 1,
+                            variables: args.variables,
+                        }];
+                }
                 args.jobLog("".concat(config.name, " does not know this file"));
                 return [2 /*return*/, {
                         outputFileObj: args.inputFileObj,
                         outputNumber: 2,
                         variables: args.variables,
                     }];
-            case 10:
-                error_6 = _e.sent();
-                errorMessage = error_6 instanceof Error ? error_6.message : String(error_6);
+            case 9:
+                error_5 = _e.sent();
+                errorMessage = error_5 instanceof Error ? error_5.message : String(error_5);
                 args.jobLog("Plugin execution failed: ".concat(errorMessage));
                 return [2 /*return*/, {
                         outputFileObj: args.inputFileObj,
                         outputNumber: 2,
                         variables: args.variables,
                     }];
-            case 11: return [2 /*return*/];
+            case 10: return [2 /*return*/];
         }
     });
 }); };

--- a/FlowPlugins/FlowHelpers/1.0.0/iso639Helper.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/iso639Helper.js
@@ -1,0 +1,86 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var iso639_3_json_1 = __importDefault(require("iso639-js/reference/iso639-3.json"));
+var alpha2to3mapping_json_1 = __importDefault(require("iso639-js/alpha2to3mapping.json"));
+var iso639_3_macrolanguages_json_1 = __importDefault(require("iso639-js/reference/iso639-3-macrolanguages.json"));
+var iso639part2CodeLookup = {};
+var iso639part2LanguageLookup = {};
+/**
+ * Process the ISO 693-2 macro languages to populate the lookup table.
+ */
+Object.keys(iso639_3_macrolanguages_json_1.default).forEach(function (macro) {
+    // Get the individual scope languages for the specified macro key.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    var individuals = (iso639_3_macrolanguages_json_1.default[macro] || [])
+        .map(function (obj) { return Object.keys(obj)[0]; });
+    // Combine macro code + found individual codes.
+    var relatedCodes6393 = [macro].concat(individuals);
+    // Convert to 639-2B.
+    var relatedCodes6392 = relatedCodes6393.filter(function (code) {
+        var _a;
+        if (Object.prototype.hasOwnProperty.call(iso639_3_json_1.default, code)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (_a = (iso639_3_json_1.default[code] || [])) === null || _a === void 0 ? void 0 : _a.part2B;
+        }
+        return null;
+    });
+    // Assign the same array to the macro and all its individuals.
+    relatedCodes6392.forEach(function (code) {
+        iso639part2CodeLookup[code.toLowerCase()] = relatedCodes6392;
+    });
+});
+/**
+ * Process the ISO 693-2 languages that do not contain a macro language definition,
+ * And then populate the language lookup table with the known macro language table values.
+ */
+Object.keys(iso639_3_json_1.default).forEach(function (code) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    var _a = iso639_3_json_1.default[code] || [], part2B = _a.part2B, part2T = _a.part2T;
+    var part2Codes = [];
+    if (part2B) {
+        part2Codes.push(part2B);
+    }
+    if (part2T && part2T !== part2B) {
+        part2Codes.push(part2T);
+    }
+    part2Codes.forEach(function (part2Code) {
+        if (part2Code && !Object.prototype.hasOwnProperty.call(iso639part2CodeLookup, part2Code.toLowerCase())) {
+            iso639part2CodeLookup[part2Code.toLowerCase()] = part2Codes;
+        }
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    var referenceName = (iso639_3_json_1.default[code] || []).referenceName;
+    if ((part2B || part2T) && referenceName) {
+        iso639part2LanguageLookup[referenceName.toLowerCase()] = iso639part2CodeLookup[part2B || part2T];
+    }
+});
+/**
+ * Helper function to get the primary and all associated ISO 639-2 language codes
+ * from an alpha2 language code (e.g. "no"),
+ * or an alpha3 language code (e.g. "kor"),
+ * or the language name in English (e.g. "swedish")
+ * @example
+ * getISO639part2Languages("Norwegian") // result: ['nor', 'nno', 'nob']
+ * getISO639part2Languages("nno") // result: ['nor', 'nno', 'nob']
+ * getISO639part2Languages("nor") // result: ['nor', 'nno', 'nob']
+ * // 'nor' is the macro language in ISO 639-2,
+ * // 'nno' and 'nob' are individual scoped languages that relate to 'nor'.
+ * getISO639part2Languages("Swedish") // result: ['swe']
+ * // 'swe' has no associated languages so it will only return the individual-scoped ISO639-2 language code.
+ */
+var getISO639part2Languages = function (codeOrName) {
+    var key = (codeOrName || '').trim().toLowerCase();
+    if (!key) {
+        return [];
+    }
+    if (key.length === 2) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        key = alpha2to3mapping_json_1.default[key] || key;
+    }
+    return iso639part2CodeLookup[key] || iso639part2LanguageLookup[key];
+};
+exports.default = getISO639part2Languages;
+exports.getISO639part2Languages = getISO639part2Languages;

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/setFlowVariablesFromRadarrOrSonarr/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/setFlowVariablesFromRadarrOrSonarr/1.0.0/index.ts
@@ -5,6 +5,10 @@ import {
 } from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
 import { getFileName } from '../../../../FlowHelpers/1.0.0/fileUtils';
 
+module.exports.dependencies = [
+  'iso639-js@1.1.3',
+];
+
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 
 // ===== CONSTANTS =====
@@ -13,16 +17,12 @@ const DEFAULT_SEASON = 1;
 const DEFAULT_EPISODE = 1;
 const DEFAULT_EPISODE_ID = '1';
 const DEFAULT_LANGUAGE_CODE = 'und';
-const LANGUAGE_API_TIMEOUT = 5000;
 const ARR_API_TIMEOUT = 10000;
 
 const API_HEADERS = {
   'Content-Type': 'application/json',
   Accept: 'application/json',
 } as const;
-
-// eslint-disable-next-line max-len
-const LANGUAGE_API_BASE_URL = 'https://data.opendatasoft.com/api/explore/v2.1/catalog/datasets/iso-language-codes-639-1-and-639-2@public/records';
 
 // ===== INTERFACES =====
 interface IBaseResponse {
@@ -70,8 +70,13 @@ const details = (): IpluginDetails => ({
   name: 'Set Flow Variables From Radarr Or Sonarr',
   description: 'Set Flow Variables From Radarr or Sonarr. The variables set are : '
     + 'ArrId (internal id for Radarr or Sonarr), '
-    + 'ArrOriginalLanguageCode (code of the orignal language (ISO 639-2) as know by Radarr or Sonarr), '
-    + 'ArrProfileLanguageCode (code of the orignal language (ISO 639-2) as know by Radarr or Sonarr), '
+    + 'ArrOriginalLanguageCode (primary original language code (ISO 639-2) as known by Radarr or Sonarr), '
+    + 'ArrOriginalLanguageCodes (comma-separated string of ISO 639-2 language codes, '
+    + 'including the primary and associated language codes), '
+    + 'ArrProfileLanguageCode (primary original language code (ISO 639-2) as known by Radarr or Sonarr), '
+    + 'ArrProfileLanguageCodes (comma-separated string of ISO 639-2 language codes, '
+    + 'including the primary and associated language codes), '
+    + 'including the maco-language code and associated individual language codes), '
     + 'ArrSeasonNumber (the season number of the episode), '
     + 'ArrEpisodeNumber (the episode number).',
   style: {
@@ -411,61 +416,19 @@ const parseContent = async (
   }
 };
 
-const languageCodeCache = new Map<string, string>();
-
-/**
- * Fetches ISO 639-2 language code from language name using external API
- * Implements caching to avoid redundant API calls
- * @param args - Plugin input arguments
- * @param languageName - The language name to look up
- * @returns ISO 639-2 (alpha3_b) language code or DEFAULT_LANGUAGE_CODE
- */
-const getLanguageCode = async (args: IpluginInputArgs, languageName: string): Promise<string> => {
-  if (!languageName || languageName.trim() === '') {
-    return '';
-  }
-
-  const normalizedName = languageName.trim().toLowerCase();
-  const cachedValue = languageCodeCache.get(normalizedName);
-  if (cachedValue !== undefined) {
-    return cachedValue;
-  }
-
-  try {
-    const url = `${LANGUAGE_API_BASE_URL}?select=alpha3_b&where=english%20%3D%20%22${
-      encodeURIComponent(languageName)
-    }%22&limit=1`;
-
-    const { data } = await args.deps.axios({
-      method: 'get',
-      url,
-      timeout: LANGUAGE_API_TIMEOUT,
-    });
-    const languageCode = data.results?.[0]?.alpha3_b ?? DEFAULT_LANGUAGE_CODE;
-
-    // Cache the result
-    languageCodeCache.set(normalizedName, languageCode);
-
-    return languageCode;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    args.jobLog(`Failed to fetch language code for "${languageName}": ${errorMessage}`);
-    return DEFAULT_LANGUAGE_CODE;
-  }
-};
-
 /**
  * Sets flow variables based on file information from Radarr/Sonarr
- * Uses parallel language code fetching for better performance
  * @param args - Plugin input arguments
  * @param fileInfo - The file information to set variables from
  */
-const setVariables = async (
+const setVariables = (
   args: IpluginInputArgs,
   fileInfo: IFileInfo,
-): Promise<void> => {
+) => {
   // eslint-disable-next-line no-param-reassign
   args.variables.user = args.variables.user || {};
+
+  const { getISO639part2Languages } = require('../../../../FlowHelpers/1.0.0/iso639Helper');
 
   // Set common variables
   // eslint-disable-next-line no-param-reassign
@@ -473,9 +436,14 @@ const setVariables = async (
   args.jobLog(`Setting variable ArrId to ${args.variables.user.ArrId}`);
 
   if (fileInfo.type === 'sonarr') {
+    const originalLanguageCodes: string[] = getISO639part2Languages(fileInfo.originalLanguageName || '');
     // eslint-disable-next-line no-param-reassign
-    args.variables.user.ArrOriginalLanguageCode = await getLanguageCode(args, fileInfo.originalLanguageName ?? '');
+    args.variables.user.ArrOriginalLanguageCode = originalLanguageCodes[0] ?? '';
     args.jobLog(`Setting variable ArrOriginalLanguageCode to ${args.variables.user.ArrOriginalLanguageCode}`);
+
+    // eslint-disable-next-line no-param-reassign
+    args.variables.user.ArrOriginalLanguageCodes = originalLanguageCodes.join(',');
+    args.jobLog(`Setting variable ArrOriginalLanguageCodes to ${args.variables.user.ArrOriginalLanguageCodes}`);
 
     // eslint-disable-next-line no-param-reassign
     args.variables.user.ArrSeasonNumber = String(fileInfo.seasonNumber);
@@ -489,34 +457,38 @@ const setVariables = async (
     args.variables.user.ArrEpisodeId = fileInfo.episodeId;
     args.jobLog(`Setting variable ArrEpisodeId to ${args.variables.user.ArrEpisodeId}`);
   } else if (fileInfo.type === 'radarr') {
-    let originalLanguageCode = '';
-    let profileLanguageCode = '';
+    let originalLanguageCodes: string[] = [];
+    let profileLanguageCodes: string[] = [];
 
     switch ((fileInfo.profileLanguageName ?? '').toLowerCase()) {
       case 'original':
         args.jobLog('Profile language is "Original", using original language');
-        originalLanguageCode = await getLanguageCode(args, fileInfo.originalLanguageName ?? '');
-        profileLanguageCode = originalLanguageCode;
+        originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+        profileLanguageCodes = originalLanguageCodes;
         break;
       case 'any':
-        args.jobLog('Profile language is "Any", setting to "und" (undetermined)');
-        originalLanguageCode = await getLanguageCode(args, fileInfo.originalLanguageName ?? '');
-        profileLanguageCode = 'und';
+        args.jobLog(`Profile language is "Any", setting to "${DEFAULT_LANGUAGE_CODE}" (undetermined`);
+        originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+        profileLanguageCodes = [DEFAULT_LANGUAGE_CODE];
         break;
       default:
-        [originalLanguageCode, profileLanguageCode] = await Promise.all([
-          getLanguageCode(args, fileInfo.originalLanguageName ?? ''),
-          getLanguageCode(args, fileInfo.profileLanguageName ?? ''),
-        ]);
+        originalLanguageCodes = getISO639part2Languages(fileInfo.originalLanguageName || '');
+        profileLanguageCodes = getISO639part2Languages(fileInfo.profileLanguageName || '');
         break;
     }
 
     // eslint-disable-next-line no-param-reassign
-    args.variables.user.ArrOriginalLanguageCode = originalLanguageCode;
-    args.jobLog(`Setting variable ArrOriginalLanguageCode to ${originalLanguageCode}`);
+    args.variables.user.ArrOriginalLanguageCode = originalLanguageCodes[0] ?? '';
+    args.jobLog(`Setting variable ArrOriginalLanguageCode to ${args.variables.user.ArrOriginalLanguageCode}`);
     // eslint-disable-next-line no-param-reassign
-    args.variables.user.ArrProfileLanguageCode = profileLanguageCode;
-    args.jobLog(`Setting variable ArrProfileLanguageCode to ${profileLanguageCode}`);
+    args.variables.user.ArrOriginalLanguageCodes = originalLanguageCodes.join(',');
+    args.jobLog(`Setting variable ArrOriginalLanguageCodes to ${args.variables.user.ArrOriginalLanguageCodes}`);
+    // eslint-disable-next-line no-param-reassign
+    args.variables.user.ArrProfileLanguageCode = profileLanguageCodes[0] ?? '';
+    args.jobLog(`Setting variable ArrProfileLanguageCode to ${args.variables.user.ArrProfileLanguageCode}`);
+    // eslint-disable-next-line no-param-reassign
+    args.variables.user.ArrProfileLanguageCodes = profileLanguageCodes.join(',');
+    args.jobLog(`Setting variable ArrProfileLanguageCodes to ${args.variables.user.ArrProfileLanguageCodes}`);
   }
 };
 
@@ -532,6 +504,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   const lib = require('../../../../../methods/lib')();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
   args.inputs = lib.loadDefaultValues(args.inputs, details);
+  await args.installClassicPluginDeps(module.exports.dependencies); // required for iso639Helper.
 
   try {
     const config: IArrConfig = {
@@ -575,7 +548,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     // Set variables if content was found
     if (fileInfo.id !== NOT_FOUND_ID && fileInfo.type !== 'unknown') {
       args.jobLog(`Successfully found content with ID: ${fileInfo.id}`);
-      await setVariables(args, fileInfo);
+      setVariables(args, fileInfo);
 
       return {
         outputFileObj: args.inputFileObj,

--- a/FlowPluginsTs/FlowHelpers/1.0.0/iso639Helper.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/iso639Helper.ts
@@ -1,0 +1,84 @@
+import iso639part3Data from 'iso639-js/reference/iso639-3.json';
+import alpha2to3mapping from 'iso639-js/alpha2to3mapping.json';
+import iso639part3MacroLanguages from 'iso639-js/reference/iso639-3-macrolanguages.json';
+
+const iso639part2CodeLookup: Record<string, string[]> = {};
+const iso639part2LanguageLookup: Record<string, string[]> = {};
+
+/**
+ * Process the ISO 693-2 macro languages to populate the lookup table.
+ */
+Object.keys(iso639part3MacroLanguages).forEach((macro) => {
+  // Get the individual scope languages for the specified macro key.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const individuals: string[] = ((iso639part3MacroLanguages as any)[macro] || [])
+    .map((obj: string) => Object.keys(obj)[0]);
+  // Combine macro code + found individual codes.
+  const relatedCodes6393 = [macro].concat(individuals);
+  // Convert to 639-2B.
+  const relatedCodes6392 = relatedCodes6393.filter((code) => {
+    if (Object.prototype.hasOwnProperty.call(iso639part3Data, code)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return ((iso639part3Data as any)[code] || [])?.part2B;
+    }
+    return null;
+  });
+  // Assign the same array to the macro and all its individuals.
+  relatedCodes6392.forEach((code: string) => {
+    iso639part2CodeLookup[code.toLowerCase()] = relatedCodes6392;
+  });
+});
+
+/**
+ * Process the ISO 693-2 languages that do not contain a macro language definition,
+ * And then populate the language lookup table with the known macro language table values.
+ */
+Object.keys(iso639part3Data).forEach((code) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { part2B, part2T } = (iso639part3Data as any)[code] || [];
+  const part2Codes: string[] = [];
+  if (part2B) {
+    part2Codes.push(part2B);
+  }
+  if (part2T && part2T !== part2B) {
+    part2Codes.push(part2T);
+  }
+  part2Codes.forEach((part2Code) => {
+    if (part2Code && !Object.prototype.hasOwnProperty.call(iso639part2CodeLookup, part2Code.toLowerCase())) {
+      iso639part2CodeLookup[part2Code.toLowerCase()] = part2Codes;
+    }
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { referenceName } = (iso639part3Data as any)[code] || [];
+  if ((part2B || part2T) && referenceName) {
+    iso639part2LanguageLookup[referenceName.toLowerCase()] = iso639part2CodeLookup[part2B || part2T];
+  }
+});
+
+/**
+ * Helper function to get the primary and all associated ISO 639-2 language codes
+ * from an alpha2 language code (e.g. "no"),
+ * or an alpha3 language code (e.g. "kor"),
+ * or the language name in English (e.g. "swedish")
+ * @example
+ * getISO639part2Languages("Norwegian") // result: ['nor', 'nno', 'nob']
+ * getISO639part2Languages("nno") // result: ['nor', 'nno', 'nob']
+ * getISO639part2Languages("nor") // result: ['nor', 'nno', 'nob']
+ * // 'nor' is the macro language in ISO 639-2,
+ * // 'nno' and 'nob' are individual scoped languages that relate to 'nor'.
+ * getISO639part2Languages("Swedish") // result: ['swe']
+ * // 'swe' has no associated languages so it will only return the individual-scoped ISO639-2 language code.
+ */
+const getISO639part2Languages = (codeOrName: string):string[] => {
+  let key = (codeOrName || '').trim().toLowerCase();
+  if (!key) {
+    return [];
+  }
+  if (key.length === 2) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    key = (alpha2to3mapping as any)[key] || key;
+  }
+  return iso639part2CodeLookup[key] || iso639part2LanguageLookup[key];
+};
+export default getISO639part2Languages;
+exports.getISO639part2Languages = getISO639part2Languages;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "import-fresh": "^3.3.0",
+        "iso639-js": "^1.1.3",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -4179,6 +4180,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/iso639-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/iso639-js/-/iso639-js-1.1.3.tgz",
+      "integrity": "sha512-RnDva++n2R5Lwo+oRlwyy9RjIkBk9JyOeiP9eHT5OTo/FuB3Ph0EJMhXPW4h1l9pB+QILR0VKkjFRi4TgliIww==",
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "import-fresh": "^3.3.0",
+    "iso639-js": "^1.1.3",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/tests/FlowPlugins/FlowHelpers/1.0.0/iso639Helper.test.ts
+++ b/tests/FlowPlugins/FlowHelpers/1.0.0/iso639Helper.test.ts
@@ -1,0 +1,31 @@
+import getISO639part2Languages from '../../../../FlowPluginsTs/FlowHelpers/1.0.0/iso639Helper';
+
+describe('iso639Helper', () => {
+  test('Accepts full language name', () => {
+    expect(getISO639part2Languages('Swedish')).toEqual(['swe']);
+    expect(getISO639part2Languages('norwegian')).toEqual(['nor', 'nno', 'nob']);
+  });
+
+  test('Fails at unknown language name', () => {
+    expect(getISO639part2Languages('Svenska')).toEqual(undefined);
+  });
+
+  test('Accepts 2 part ISO 639-1 code', () => {
+    expect(getISO639part2Languages('JA')).toEqual(['jpn']);
+    expect(getISO639part2Languages('no')).toEqual(['nor', 'nno', 'nob']);
+  });
+
+  test('Fails at unknown 2 part ISO 639-1 code', () => {
+    expect(getISO639part2Languages('zz')).toEqual(undefined);
+  });
+
+  test('Accepts 3 part ISO 639-2 code', () => {
+    expect(getISO639part2Languages('fin')).toEqual(['fin']);
+    expect(getISO639part2Languages('Nno')).toEqual(['nor', 'nno', 'nob']);
+  });
+
+  test('Fails at unknown 3 part ISO 639-2 code', () => {
+    expect(getISO639part2Languages('zzz')).toEqual(undefined);
+    expect(getISO639part2Languages('cmn')).toEqual(undefined); // Mandarin Chinese in ISO 639-3
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "resolveJsonModule": true,               /* Enables importing .json files. */
     /* Advanced Options */
     "skipLibCheck": true, /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */


### PR DESCRIPTION
Support finding the associated ISO 639-2 language codes, using a package containing JSON files instead of the external API.

The new properties contain all found language codes so that they can be used for exclude filters like removing unwanted audio, which is my main use-case.

---
Example using classic plugin `Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio` but slightly customized with better logging.

With  `{{args.variables.user.ArrProfileLanguageCode}},{{args.variables.user.ArrOriginalLanguageCode}}`:
```
"infoLog": "Removing unwanted audio...
languages: nor,nor
Found unwanted index 1: nob
Found unwanted index 2: eng
All audio tracks are unwanted, skipping file."
```

With `{{args.variables.user.ArrProfileLanguageCodes}},{{args.variables.user.ArrOriginalLanguageCodes}}`:
```
"infoLog": "Removing unwanted audio...
languages: nor,nno,nob,nor,nno,nob
Found wanted index 1: nob
Found unwanted index 2: eng
Found unwanted audio
It will be removed"
```

---
### Misc
Maybe also expose ArrProfileLanguageCode(s) for Sonarr to avoid undefined variables, even though we can't grab it (or maybe we can scan the Custom Formats?).